### PR TITLE
130/fix/text and tooltip

### DIFF
--- a/frontend/src/pages/ListMeds/ListMeds.tsx
+++ b/frontend/src/pages/ListMeds/ListMeds.tsx
@@ -21,19 +21,21 @@ function ListMeds () {
           return res.json()
         }})
       .then(data => {
-        const details = data.map((med: {name: string}) => {
-        return fetch(`${baseUrl}/V1/medications/?name=${med.name}`)
-          .then(res => {
-            if (!res.ok) {
-              throw new Error ('Could not get medication details')
-            } else {
-              return res.json()
-            }})
+        data.sort((a, b) => {
+          const nameA = a.name.toUpperCase()
+          const nameB = b.name.toUpperCase()
+          if (nameA < nameB) {
+            return -1
+          }
+          if (nameA > nameB) {
+            return 1
+          }
+        
+          return 0
         })
 
-        return Promise.all(details)
+        setMedications(data)
       })
-      .then(listWithDetails => setMedications(listWithDetails))
       .catch(e => setErrors((prev) => [...prev, e.message]))
   }, [])
 

--- a/frontend/src/pages/PatientManager/PatientSummary.tsx
+++ b/frontend/src/pages/PatientManager/PatientSummary.tsx
@@ -209,7 +209,12 @@ const PatientSummary = ({
                           <span className="font-medium ">
                             {patientInfo.Suicide == "Yes" ? (
                               <li className="flex items-center justify-between  border-b border-gray-900/10 py-4 pl-4 pr-5 text-sm leading-4 hover:bg-indigo-100 ">
-                                Patient has a history of suicide attempts
+                                <Tooltip text="Lithium is the only medication on the market that has been proven to reduce suicidality in patients with bipolar disorder, so it will be shown at the top of the suggested medications list.">
+                                  Patient has a history of suicide attempts
+                                  <span className="material-symbols-outlined  ml-1">
+                                    info
+                                  </span>
+                                </Tooltip>
                               </li>
                             ) : (
                               ""

--- a/frontend/src/pages/PatientManager/PatientSummary.tsx
+++ b/frontend/src/pages/PatientManager/PatientSummary.tsx
@@ -209,7 +209,7 @@ const PatientSummary = ({
                           <span className="font-medium ">
                             {patientInfo.Suicide == "Yes" ? (
                               <li className="flex items-center justify-between  border-b border-gray-900/10 py-4 pl-4 pr-5 text-sm leading-4 hover:bg-indigo-100 ">
-                                Patient has attempted suicide
+                                Patient has a history of suicide attempts
                               </li>
                             ) : (
                               ""

--- a/server/api/views/listMeds/views.py
+++ b/server/api/views/listMeds/views.py
@@ -74,7 +74,7 @@ def list_or_detail_medication(request):
             return JsonResponse({'error': 'Medication not found'}, status=404)
     else:
         medications = Medication.objects.all()
-        response_data = [{'name': med.name} for med in medications]
+        response_data = [{'name': med.name, 'benefits': med.benefits, 'risks': med.risks} for med in medications]
 
     # safe=False is needed if response_data is a list
     return JsonResponse(response_data, safe=False)


### PR DESCRIPTION
this PR will close #130 

- Updated text and tooltip of history of suicide
- Refactored ListMeds.tsx to only call api once, results are sorted alphabetically
- Refactored list_or_detail_medication method in view to include all information in full list
<img width="835" alt="Screen Shot 2024-05-02 at 2 50 54 PM" src="https://github.com/CodeForPhilly/balancer-main/assets/123565022/211f6927-9307-4f4f-82bc-fbcddb07309a">
<img width="864" alt="Screen Shot 2024-05-02 at 3 24 55 PM" src="https://github.com/CodeForPhilly/balancer-main/assets/123565022/3dce6bab-f024-48f9-aeb0-c7a087fa9b1e">
