### PR TITLE
Update browser tab text to 'Balancer'

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
-  <title>Balancer - A Tool To Assist</title>
+  <title>Balancer</title>
 </head>
 
 <body>


### PR DESCRIPTION
This pull request is to address Issue #140 - https://github.com/CodeForPhilly/balancer-main/issues/140

I updated frontend/index.html to only say 'Balancer'

I am open to any feedback or further modifications if needed.