### PR TITLE
Fix Double Submit Bug - Add Diagnosis enum and set default patient info state as 'Manic'

### DIFF
--- a/frontend/src/pages/PatientManager/NewPatientForm.tsx
+++ b/frontend/src/pages/PatientManager/NewPatientForm.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, ChangeEvent, useEffect, useState } from "react";
 import axios from "axios";
 import { v4 as uuidv4 } from "uuid";
-import { PatientInfo } from "./PatientTypes";
+import { PatientInfo, Diagnosis } from "./PatientTypes";
 import Tooltip from "../../components/Tooltip";
 // import ErrorMessage from "../../components/ErrorMessage";
 
@@ -52,7 +52,7 @@ const NewPatientForm = ({
 
   const [newPatientInfo, setNewPatientInfo] = useState<PatientInfo>({
     ID: "",
-    Diagnosis: "Null",
+    Diagnosis: Diagnosis.Manic,
     OtherDiagnosis: "",
     Description: "",
     CurrentMedications: "",
@@ -94,11 +94,6 @@ const NewPatientForm = ({
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // const payload = {
-    //   state:
-    //     newPatientInfo.Diagnosis !== null ? newPatientInfo.Diagnosis : "Null",
-    // };
-
     // send payload to backend using the new interface
     const payload: PatientInfoInterface = {
       id: newPatientInfo.ID,
@@ -120,14 +115,6 @@ const NewPatientForm = ({
       riskPregnancy: newPatientInfo.risk_pregnancy == "Yes",
     };
     console.log(newPatientInfo);
-
-    // Check if Diagnosis is "Null"
-    if (newPatientInfo.Diagnosis === "Null") {
-      newPatientInfo.Diagnosis = "Manic";
-      // setErrors(["Please select a current state."]);
-      // window.scrollTo({ top: 0, behavior: "smooth" });
-      return; // Prevent form submission
-    }
 
     setIsLoading(true); // Start loading
 
@@ -186,11 +173,11 @@ const NewPatientForm = ({
   };
 
   const handleDiagnosisChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const selectedValue = e.target.value;
+    const selectedValue = e.target.value as keyof typeof Diagnosis;
 
     setNewPatientInfo({
       ...newPatientInfo,
-      Diagnosis: selectedValue,
+      Diagnosis: Diagnosis[selectedValue],
       OtherDiagnosis: "", // Reset the OtherDiagnosis value
     });
   };
@@ -199,7 +186,7 @@ const NewPatientForm = ({
     setNewPatientInfo((prevPatientInfo) => ({
       ...prevPatientInfo,
       ID: "",
-      Diagnosis: "Null",
+      Diagnosis: Diagnosis.Manic,
       OtherDiagnosis: "",
       Description: "",
       CurrentMedications: "",
@@ -224,7 +211,7 @@ const NewPatientForm = ({
     setNewPatientInfo((prevPatientInfo) => ({
       ...prevPatientInfo,
       ID: "",
-      Diagnosis: "Null",
+      Diagnosis: Diagnosis.Manic,
       OtherDiagnosis: "",
       Description: "",
       CurrentMedications: "",
@@ -341,11 +328,11 @@ const NewPatientForm = ({
                     autoComplete="current-state"
                     className={isLoading ? " url_input_loading" : "dropdown"}
                   >
-                    {/* <option value="Null"> </option> */}
-                    <option value="Manic"> Manic </option>
-                    <option value="Depressed">Depressed</option>
-                    <option value="Hypomanic">Hypomanic</option>
-                    <option value="Euthymic">Euthymic</option>
+                    {Object.values(Diagnosis).map((diagnosis) => (
+                      <option key={diagnosis} value={diagnosis}>
+                        {diagnosis}
+                      </option>
+                    ))}
                     {/* <option value="Mixed">Mixed</option> */}
                   </select>
                 </div>

--- a/frontend/src/pages/PatientManager/PatientTypes.ts
+++ b/frontend/src/pages/PatientManager/PatientTypes.ts
@@ -1,6 +1,6 @@
 export interface PatientInfo {
   ID?: string;
-  Diagnosis?: string;
+  Diagnosis?: Diagnosis;
   OtherDiagnosis?: string;
   Description?: string;
   Depression?: string;
@@ -25,7 +25,7 @@ export interface PatientInfo {
 
 export interface NewPatientInfo {
   ID?: string;
-  Diagnosis?: string;
+  Diagnosis?: Diagnosis;
   OtherDiagnosis?: string;
   Description?: string;
   Depression?: string;
@@ -42,4 +42,11 @@ export interface NewPatientInfo {
   Suicide: string;
   Kidney: string;
   Liver: string;
+}
+
+export enum Diagnosis {
+  Manic = "Manic",
+  Depressed = "Depressed",
+  Hypomanic = "Hypomanic",
+  Euthymic = "Euthymic",
 }


### PR DESCRIPTION
This change will fix bug #100 

The issue was caused by the default Diagnosis being set to _Null_. When the submit button was pressed, the diagnosis would change to _Manic_, but not submit until it was pressed again.

### Changes:
- Created a string enum for each Diagnosis.
- Set the default diagnosis in the patient info state as _Manic_
- Dynamically create `<option>`s for each Diagnosis from the enum