### PR TITLE
Add conditional to hide LoginMenuDropDown at login page

### DIFF
--- a/frontend/src/pages/Layout/Layout.tsx
+++ b/frontend/src/pages/Layout/Layout.tsx
@@ -24,22 +24,17 @@ export const Layout = ({
   const location = useLocation();
 
   useEffect(() => {
-    // console.log(isAuthenticated);
     if (!isAuthenticated) {
-      setShowLoginMenu(true);
-    }
-    if (location.pathname === "/login" && !isAuthenticated) {
-      setShowLoginMenu(false);
-    } else if (location.pathname === "/resetpassword" && !isAuthenticated) {
-      setShowLoginMenu(false);
-    } else if (
-      (location.pathname.includes("password") ||
-        location.pathname.includes("reset")) &&
-      !isAuthenticated
-    ) {
-      setShowLoginMenu(false);
-    } else if (!isAuthenticated) {
-      setShowLoginMenu(true);
+      if (
+        location.pathname === "/login" ||
+        location.pathname === "/resetpassword" ||
+        location.pathname.includes("password") ||
+        location.pathname.includes("reset")
+      ) {
+        setShowLoginMenu(false);
+      } else {
+        setShowLoginMenu(true);
+      }
     }
   }, [isAuthenticated, location.pathname]);
 
@@ -54,7 +49,7 @@ export const Layout = ({
         <div className="gradient" />
       </div>
       <div className="relative z-10 mx-auto flex w-full flex-col items-center">
-        {!isAuthenticated && (
+        {!isAuthenticated && showLoginMenu && (
           <LoginMenuDropDown
             showLoginMenu={showLoginMenu}
             handleLoginMenu={handleLoginMenu}


### PR DESCRIPTION
@taichan03 found an issue with text overlay on the log-in screen on mobile:
![image](https://github.com/user-attachments/assets/751e9714-169b-4ce0-9041-4c69faaea8d8)

This pull request resolves this bug by adding a conditional on when the `LoginMenuDropDown` component should be shown. It also cleans up the logic of displaying the component.

![image](https://github.com/user-attachments/assets/8ce8aa9f-aa1a-4381-a930-ea88e7e01b7a)
