### PR TITLE
fix: unused type HourglassSpinner

### DIFF
--- a/frontend/src/pages/ListMeds/ListMeds.tsx
+++ b/frontend/src/pages/ListMeds/ListMeds.tsx
@@ -1,6 +1,5 @@
 import Layout from "../Layout/Layout";
 import Welcome from "../../components/Welcome/Welcome";
-import HourglassSpinner from "../../components/HourglassSpinner/HourglassSpinner";
 import ErrorMessage from "../../components/ErrorMessage";
 // import { MedData } from "./MedTypes";
 import { useState, useEffect } from "react";


### PR DESCRIPTION
the line

`import HourglassSpinner from "../../components/HourglassSpinner/HourglassSpinner";`

is making the frontend container fail on the image build as the type is being unused.

![image](https://github.com/user-attachments/assets/fd7171aa-81ab-4335-8418-62f33b2445fa)
