### PR TITLE
BUGFIX: OpenAI model reasoning summary requires org verification

### DIFF
--- a/server/api/views/assistant/views.py
+++ b/server/api/views/assistant/views.py
@@ -223,7 +223,8 @@ class Assistant(APIView):
             MODEL_DEFAULTS = {
                 "instructions": INSTRUCTIONS,
                 "model": "gpt-5-nano",  # 400,000 token context window
-                "reasoning": {"effort": "low", "summary": "auto"},
+                # A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process.
+                "reasoning": {"effort": "low", "summary": None},
                 "tools": tools,
             }
 


### PR DESCRIPTION
OpenAI's API has a reasoning summary parameter that I turned on for debugging by verifying my account with OpenAI and using my API key. Balancer's OpenAI account isn't verified with OpenAI so that debugging parameter has to be turned off. This PR changes the summary parameter from auto to None. The model output is the same with that parameter turned off  and it it is still performing "reasoning" but we can't see a summary of its process for debugging

https://help.openai.com/en/articles/10362446-api-model-availability-by-usage-tier-and-verification-status
https://help.openai.com/en/articles/10910291-api-organization-verification