### PR TITLE
Update VITE_API_BASE_URL to point to the new prod url

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://balancer.live.k8s.phl.io/
+VITE_API_BASE_URL=https://balancerproject.org/


### PR DESCRIPTION
Update the prod domain to use balancerproject.org.

#427