### PR TITLE
ci: refactor pipelines for continuous deployment to sandbox

### DIFF
--- a/.github/workflows/containers-publish.yml
+++ b/.github/workflows/containers-publish.yml
@@ -3,6 +3,8 @@ name: "Containers: Publish"
 on:
   release:
     types: [published]
+  push:
+    branches: [develop]
 
 permissions:
   packages: write
@@ -24,7 +26,13 @@ jobs:
       - name: Compute Docker container image addresses
         run: |
           DOCKER_REPOSITORY="ghcr.io/${GITHUB_REPOSITORY,,}"
-          DOCKER_TAG="${GITHUB_REF:11}"
+          
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            DOCKER_TAG="${GITHUB_REF:11}"
+          else
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            DOCKER_TAG="dev-${SHORT_SHA}"
+          fi
 
           echo "DOCKER_REPOSITORY=${DOCKER_REPOSITORY}" >> $GITHUB_ENV
           echo "DOCKER_TAG=${DOCKER_TAG}" >> $GITHUB_ENV
@@ -51,3 +59,12 @@ jobs:
 
       - name: "Push Docker container image app:v*"
         run: docker push "${DOCKER_REPOSITORY}/app:${DOCKER_TAG}"
+
+      - name: Save Docker Tag
+        run: echo "${DOCKER_TAG}" > docker_tag.txt
+
+      - name: Upload Docker Tag
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-tag
+          path: docker_tag.txt

--- a/.github/workflows/deploy-downstream.yml
+++ b/.github/workflows/deploy-downstream.yml
@@ -1,8 +1,10 @@
 name: "Deploy: Downstream Clusters"
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Containers: Publish"]
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       tag:
@@ -14,6 +16,7 @@ jobs:
   update-sandbox:
     name: Update Sandbox Cluster
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') }}
     outputs:
       tag: ${{ steps.get_tag.outputs.TAG }}
     steps:
@@ -26,8 +29,12 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "TAG=${{ inputs.tag }}" >> $GITHUB_OUTPUT
           else
-            echo "TAG=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+            gh run download ${{ github.event.workflow_run.id }} -n docker-tag
+            TAG=$(cat docker_tag.txt)
+            echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Sandbox Cluster
         uses: actions/checkout@v4
@@ -57,9 +64,25 @@ jobs:
 
   update-live:
     name: Update Live Cluster
-    needs: update-sandbox
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release') }}
     steps:
+      - name: Checkout App
+        uses: actions/checkout@v4
+
+      - name: Get Release Tag
+        id: get_tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "TAG=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            gh run download ${{ github.event.workflow_run.id }} -n docker-tag
+            TAG=$(cat docker_tag.txt)
+            echo "TAG=${TAG}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout Live Cluster
         uses: actions/checkout@v4
         with:
@@ -71,7 +94,7 @@ jobs:
         working-directory: live/balancer
         run: |
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          ./kustomize edit set image ghcr.io/codeforphilly/balancer-main/app:${{ needs.update-sandbox.outputs.tag }}
+          ./kustomize edit set image ghcr.io/codeforphilly/balancer-main/app:${{ steps.get_tag.outputs.TAG }}
           rm kustomize
 
       - name: Create Live PR
@@ -79,9 +102,9 @@ jobs:
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           path: live
-          commit-message: "Deploy balancer ${{ needs.update-sandbox.outputs.tag }} to live"
-          title: "Deploy balancer ${{ needs.update-sandbox.outputs.tag }}"
-          body: "Updates balancer image tag to ${{ needs.update-sandbox.outputs.tag }}"
-          branch: "deploy/balancer-${{ needs.update-sandbox.outputs.tag }}"
+          commit-message: "Deploy balancer ${{ steps.get_tag.outputs.TAG }} to live"
+          title: "Deploy balancer ${{ steps.get_tag.outputs.TAG }}"
+          body: "Updates balancer image tag to ${{ steps.get_tag.outputs.TAG }}"
+          branch: "deploy/balancer-${{ steps.get_tag.outputs.TAG }}"
           base: main
           delete-branch: true


### PR DESCRIPTION
Refactors CI/CD workflows to:
- Build Docker images on push to 'develop' (tagged with dev-SHA).
- Deploy automatically to Sandbox cluster by creating a PR on successful build from 'develop'.
- Deploy to Live cluster by creating a PR on successful release build.
- Pass Docker tags reliably between workflows using artifacts.