### PR TITLE
Fix: duplicate healthcheck key in docker-compose db service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,6 @@ services:
     networks:
       app_net:
         ipv4_address: 192.168.0.2
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U balancer -d balancer_dev"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
 
   pgadmin:
     image: dpage/pgadmin4


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR -->
This PR fixes a duplicate `healthcheck` key in `docker-compose.yml` db service section. I deleted one of the `healthcheck`keys.

I kept the one with a 10s interval to stay consistent with the rest of the builds, but we can definitely adjust this if needed.


## Related Issue
<!-- If this PR relates to an issue, link it here -->
N/A: Dicussed with @TineoC in chat  

## Manual Tests
<!-- Help reviewers understand your changes work: paste terminal commands/output or attach a screen capture video -->
`docker compose up --build` successfully builds now

## Automated Tests
<!-- Help prove your changes work and prevent regressions: describe tests added or explain why tests aren't applicable -->
No automated tests were added since this change only affects Docker configuration

## Documentation
<!-- Help others understand your changes: list any documentation you've updated or note if updates aren't needed -->
no documentation updates required.

## Reviewers
<!-- Tag the person or team who should review this PR -->
@TineoC 

## Notes
<!-- Any additional context, concerns, or discussion points for reviewers -->