### PR TITLE
fix: changed donate button link to direct to balancer github page

### DIFF
--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -62,7 +62,7 @@ function Footer() {
           >
             Leave feedback
           </Link>
-          <a href="https://www.flipcause.com/secure/cause_pdetails/MjMyMTIw"
+          <a href="https://github.com/CodeForPhilly/balancer-main"
             target="_blank"
             className="flex justify-center text-black hover:border-blue-600 hover:text-blue-600 hover:no-underline"
           >

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -64,9 +64,9 @@ function Footer() {
           </Link>
           <a href="https://github.com/CodeForPhilly/balancer-main"
             target="_blank"
-            className="flex justify-center text-black hover:border-blue-600 hover:text-blue-600 hover:no-underline"
+            className="flex justify-center text-center text-black hover:border-blue-600 hover:text-blue-600 hover:no-underline"
           >
-            Donate
+            Support Development
           </a>
           <Link
             to="/help"

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -165,7 +165,7 @@ const Header: React.FC<LoginFormProps> = ({ isAuthenticated, isSuperuser }) => {
               Leave Feedback
             </Link>
             <a
-              href="https://www.flipcause.com/secure/cause_pdetails/MjMyMTIw"
+              href="https://github.com/CodeForPhilly/balancer-main"
               target="_blank"
               className="header-nav-item"
             >

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -169,7 +169,7 @@ const Header: React.FC<LoginFormProps> = ({ isAuthenticated, isSuperuser }) => {
               target="_blank"
               className="header-nav-item"
             >
-              Donate
+              Support Development
             </a>
             {isAuthenticated && isSuperuser && (
               <div

--- a/frontend/src/components/Header/MdNavBar.tsx
+++ b/frontend/src/components/Header/MdNavBar.tsx
@@ -124,7 +124,7 @@ const MdNavBar = (props: LoginFormProps) => {
                           target="_blank"
                           className="mr-9 text-black hover:border-b-2 hover:border-blue-600 hover:text-black hover:no-underline"
                         >
-                          Donate
+                          Support Development
                         </a>
                     </li>
                     {isAuthenticated &&

--- a/frontend/src/components/Header/MdNavBar.tsx
+++ b/frontend/src/components/Header/MdNavBar.tsx
@@ -120,7 +120,7 @@ const MdNavBar = (props: LoginFormProps) => {
                         </Link>
                     </li>
                     <li className="border-b border-gray-300 p-4">
-                        <a href="https://www.flipcause.com/secure/cause_pdetails/MjMyMTIw"
+                        <a href="https://github.com/CodeForPhilly/balancer-main"
                           target="_blank"
                           className="mr-9 text-black hover:border-b-2 hover:border-blue-600 hover:text-black hover:no-underline"
                         >

--- a/frontend/src/pages/About/About.tsx
+++ b/frontend/src/pages/About/About.tsx
@@ -79,7 +79,7 @@ function About() {
           <div className="mb-20 mt-5 flex flex-row flex-wrap justify-center gap-4">
             <a href="https://github.com/CodeForPhilly/balancer-main" target="_blank">
               <button className="btnBlue transition-transform focus:outline-none focus:ring focus:ring-blue-200">
-                Donate
+                Support Development
               </button>
             </a>
 

--- a/frontend/src/pages/About/About.tsx
+++ b/frontend/src/pages/About/About.tsx
@@ -77,7 +77,7 @@ function About() {
             </div>
           </div>
           <div className="mb-20 mt-5 flex flex-row flex-wrap justify-center gap-4">
-            <a href="https://www.flipcause.com/secure/cause_pdetails/MjMyMTIw" target="_blank">
+            <a href="https://github.com/CodeForPhilly/balancer-main" target="_blank">
               <button className="btnBlue transition-transform focus:outline-none focus:ring focus:ring-blue-200">
                 Donate
               </button>


### PR DESCRIPTION
## Description
Updated the 4 donate buttons to direct to the Balancer GitHub repo instead of the old donation site. 
Let me know if this is wrong or if I've misunderstood the issue.


## Related Issue
Closes #445 


## Manual Tests
Ran app locally, verified all `donate` buttons redirect to the right place.


## Automated Tests
N/A, just a static URL change


## Documentation
No documentation updates needed.


## Reviewers
@sahilds1 


## Notes
The donation site link was hardcoded in 4 separate places. It may be worth extracting them into a shared constant to make updates like this simpler in the future.