### PR TITLE
Fixed error 1 (openAI title sanitization) and added unit tests

### DIFF
--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -57,7 +57,7 @@ class TestGenerateTitle(unittest.TestCase):
     def test_falls_back_to_chatgpt_if_no_title_found(self, mock_openAI):
         doc = MagicMock()
         doc.metadata = {"title": None}
-        doc.get_text.return_value = []
+        doc[0].get_text.return_value = []
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -72,7 +72,7 @@ class TestGenerateTitle(unittest.TestCase):
     def test_strips_quotes_from_openai_title(self, mock_openAI):
         doc = MagicMock()
         doc.metadata = {"title": None}
-        doc.get_text.return_value = []
+        doc[0].get_text.return_value = []
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -87,7 +87,7 @@ class TestGenerateTitle(unittest.TestCase):
     def test_truncates_long_openai_title(self, mock_openAI):
         doc = MagicMock()
         doc.metadata = {"title": None}
-        doc.get_text.return_value = []
+        doc[0].get_text.return_value = []
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -53,7 +53,7 @@ class TestGenerateTitle(unittest.TestCase):
         expected_title = "Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia"
         self.assertEqual(expected_title, title.generate_title(doc))
 
-    @patch("api.services.openai_services.openAIServices.openAI")
+    @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_falls_back_to_chatgpt_if_no_title_found(self, mock_openAI):
         doc = MagicMock()
         doc.metadata = {"title": None}
@@ -68,7 +68,7 @@ class TestGenerateTitle(unittest.TestCase):
 
         self.assertTrue(mock_openAI.called)
 
-    @patch("api.services.openai_services.openAIServices.openAI")
+    @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_strips_quotes_from_openai_title(self, mock_openAI):
         doc = MagicMock()
         doc.metadata = {"title": None}
@@ -83,7 +83,7 @@ class TestGenerateTitle(unittest.TestCase):
 
         self.assertEqual(result, "Updated CANMAT/ISBD Guidelines for Treating Mixed Features in Bipolar Disorder")
 
-    @patch("api.services.openai_services.openAIServices.openAI")
+    @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_truncates_long_openai_title(self, mock_openAI):
         doc = MagicMock()
         doc.metadata = {"title": None}

--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -67,3 +67,33 @@ class TestGenerateTitle(unittest.TestCase):
         title.generate_title(doc)
 
         self.assertTrue(mock_openAI.called)
+
+    @patch("api.services.openai_services.openAIServices.openAI")
+    def test_strips_quotes_from_openai_title(self, mock_openAI):
+        doc = MagicMock()
+        doc.metadata = {"title": None}
+        doc.get_text.return_value = []
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '"Updated CANMAT/ISBD Guidelines for Treating Mixed Features in Bipolar Disorder"'
+        mock_openAI.return_value = mock_response
+
+        result = title.generate_title(doc)
+
+        self.assertEqual(result, "Updated CANMAT/ISBD Guidelines for Treating Mixed Features in Bipolar Disorder")
+
+    @patch("api.services.openai_services.openAIServices.openAI")
+    def test_truncates_long_openai_title(self, mock_openAI):
+        doc = MagicMock()
+        doc.metadata = {"title": None}
+        doc.get_text.return_value = []
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "A" * 300
+        mock_openAI.return_value = mock_response
+
+        result = title.generate_title(doc)
+
+        self.assertLessEqual(len(result), 255)

--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -96,4 +96,5 @@ class TestGenerateTitle(unittest.TestCase):
 
         result = title.generate_title(doc)
 
+        # Ensure the title is truncated to fit the UploadFile model's title field (max_length=255), since OpenAI responses may exceed this limit
         self.assertLessEqual(len(result), 255)

--- a/server/api/views/uploadFile/title.py
+++ b/server/api/views/uploadFile/title.py
@@ -58,4 +58,5 @@ def summarize_pdf(pdf: fitz.Document) -> str:
     prompt = "Please provide a title for this document. The title should be less than 256 characters and will be displayed on a webpage."
     response = openAIServices.openAI(
         first_page_content, prompt, model='gpt-4o', temp=0.0)
-    return response.choices[0].message.content
+    title = response.choices[0].message.content.strip().strip('"').strip("'")
+    return title[:255]

--- a/server/api/views/uploadFile/title.py
+++ b/server/api/views/uploadFile/title.py
@@ -59,4 +59,5 @@ def summarize_pdf(pdf: fitz.Document) -> str:
     response = openAIServices.openAI(
         first_page_content, prompt, model='gpt-4o', temp=0.0)
     title = response.choices[0].message.content.strip().strip('"').strip("'")
+    # Truncate to fit UploadFile model's max_length=255 title field as a final safeguard
     return title[:255]

--- a/server/api/views/uploadFile/views.py
+++ b/server/api/views/uploadFile/views.py
@@ -12,6 +12,9 @@ from ...models.model_embeddings import Embeddings
 import fitz
 from django.db import transaction
 from .title import generate_title
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class UploadFileView(APIView):
@@ -124,6 +127,7 @@ class UploadFileView(APIView):
             )
         except Exception as e:
             # Handle potential errors
+            logger.exception("File upload failed for '%s': %s", uploaded_file.name, e)
             return Response({"message": f"Error processing file and embeddings: {str(e)}"},
                             status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
## Description
Fixes the `/v1/api/uploadFile` endpoint failure that occurs when title extraction falls back to OpenAI. OpenAI sometimes returns titles wrapped in quotes (ex: '"Updated CANMAT/ISBD Guidelines..."'). The raw response is saved without sanitization, which caused a 400 error in the reported logs. This PR strips wrapping quotes and whitespace from OpenAI-generated titles before returning.

This PR also truncates titles to 255 characters so the title is guaranteed to fit in the `CharField` size limit. This is just an extra safeguard in the case where OpenAI doesn't respect the 256 character limit specified in the prompt.


## Related Issue
Addresses part of #390 


## Manual Tests
(I'm not able to manually test right now, looking for help getting my local dev environment and workflow set up)

## Automated Tests
Added 2 new unit tests to `test_title.py`:
- `test_strips_quotes_from_openai_title` verifies wrapping quotes are removed from OpenAI-generated titles
- `test_truncates_long_openai_title` verifies titles exceeding 255 characters are truncated 

All tests passing (4 existing + 2 new)

## Reviewers
@sahilds1 

## Notes
Also added some more logs to the error handler in `views.py` so errors include full traceback.

This only addresses the first error from the original issue. The second error is being caused by a separate bug which I think has to do with the upload component in `UploadFile.tsx` where we're setting `Content-Type: multipart/form-data` but not providing a boundary parameter. Needs further investigation and manual testing.

(This is a separate issue) When I tried uploading files manually in my local dev environment, I got `Unauthorized: /api/v1/api/uploadFile` which is not a valid route, right? Has anyone seen this issue?