### PR TITLE
Fix 401 by using adminApi instead of raw axios

### DIFF
--- a/frontend/src/pages/DocumentManager/UploadFile.tsx
+++ b/frontend/src/pages/DocumentManager/UploadFile.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import axios from "axios";
+import { adminApi } from "../../api/apiClient";
 import TypingAnimation from "../../components/Header/components/TypingAnimation.tsx";
 import Layout from "../Layout/Layout.tsx";
 
@@ -22,14 +22,9 @@ const UploadFile: React.FC = () => {
     formData.append("file", file);
 
     try {
-      const response = await axios.post(
+      const response = await adminApi.post(
         `/api/v1/api/uploadFile`,
         formData,
-        {
-          headers: {
-            "Content-Type": "multipart/form-data"
-          },
-        }
       );
       console.log("File uploaded successfully", response.data);
     } catch (error) {


### PR DESCRIPTION
## Description
File uploads were resulting in `401 Unauthorized`. 

This was becauase `UploadFile.tsx` was using a raw `axios.post()` call instead of the `adminApi` client, so no JWT Authorization header was being sent with upload requests.  `uploadFile` POST requests require authentication, so uploads were failing with 401. 

@sahilds1 I tried your suggested fix and it worked. I was able to upload a file.

To reiterate the fix, I replaced `axios.post()` with `adminApi.post()`, which automatically attaches the JWT token via its request interceptor. 
I also removed the explicit `Content-Type: multipart/form-data` header since [Axios auto-sets it](https://github.com/axios/axios/issues/318) (with the required boundary parameter) when the body is a `FormData`. 


## Related Issue
Closes #467 
Also may close #390, but I'm not sure 

## Manual Tests
I manually tested these changes by uploading a pdf and confirming successful upload with 201

## Reviewers
@sahilds1 @taichan03 

## Notes
This might fix the 2nd error in issue #390, but would want to manually test with the original file to see if the error is still happening.