### PR TITLE
Fix: File downloads and opens used wrong API URL

### DIFF
--- a/frontend/src/pages/Files/ListOfFiles.tsx
+++ b/frontend/src/pages/Files/ListOfFiles.tsx
@@ -61,7 +61,7 @@ const ListOfFiles: React.FC<{ showTable?: boolean }> = ({
   const handleDownload = async (guid: string, fileName: string) => {
     try {
       setDownloading(guid);
-      const { data } = await publicApi.get(`/v1/api/uploadFile/${guid}`, { responseType: 'blob' });
+      const { data } = await publicApi.get(`/api/v1/api/uploadFile/${guid}`, { responseType: 'blob' });
 
       const url = window.URL.createObjectURL(new Blob([data]));
       const link = document.createElement("a");

--- a/frontend/src/pages/Files/ListOfFiles.tsx
+++ b/frontend/src/pages/Files/ListOfFiles.tsx
@@ -82,7 +82,7 @@ const ListOfFiles: React.FC<{ showTable?: boolean }> = ({
   const handleOpen = async (guid: string) => {
     try {
       setOpening(guid);
-      const { data } = await publicApi.get(`/v1/api/uploadFile/${guid}`, { responseType: 'arraybuffer' });
+      const { data } = await publicApi.get(`/api/v1/api/uploadFile/${guid}`, { responseType: 'arraybuffer' });
 
       const file = new Blob([data], { type: 'application/pdf' });
       const fileURL = window.URL.createObjectURL(file);


### PR DESCRIPTION
## Description
I fixed the API URL path in `handleDownload` in `ListOfFiles.tsx`. It was missing the `/api` prefix specified in `balancer_backend/urls.py`, so file downloads were resulting in 400 error.

While looking into this error I also found that `handleOpen` in `ListOfFiles.tsx` used the same wrong URL. `handleOpen` is called from the Help/DataSources page and, as expected, was resulting in 400 errors when I tried to view the files. The same fix as `handleDownload` fixed this issue, and this View button acts as expected now.


## Related Issue
https://codeforphilly.slack.com/archives/C059A5JHX8X/p1772128435712889


## Manual Tests
Locally tested file downloads, which now successfully download the real PDF.
Locally tested file opens from the Help/DataSources page, which now successfully open the PDF in a new tab.


## Reviewers
@sahilds1 
