### PR TITLE
fix: openAI fallback crash in title generation

### DIFF
--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -61,9 +61,10 @@ class TestGenerateTitle(unittest.TestCase):
 
         mock_openAI.return_value = "A Study Regarding The Efficacy of Drugs"
 
-        title.generate_title(doc)
+        result = title.generate_title(doc)
 
         self.assertTrue(mock_openAI.called)
+        self.assertEqual(result, "A Study Regarding The Efficacy of Drugs")
 
     @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_strips_quotes_from_openai_title(self, mock_openAI):

--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -59,10 +59,7 @@ class TestGenerateTitle(unittest.TestCase):
         doc.metadata = {"title": None}
         doc[0].get_text.return_value = []
 
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "A Study Regarding The Efficacy of Drugs"
-        mock_openAI.return_value = mock_response
+        mock_openAI.return_value = "A Study Regarding The Efficacy of Drugs"
 
         title.generate_title(doc)
 
@@ -74,10 +71,7 @@ class TestGenerateTitle(unittest.TestCase):
         doc.metadata = {"title": None}
         doc[0].get_text.return_value = []
 
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '"Updated CANMAT/ISBD Guidelines for Treating Mixed Features in Bipolar Disorder"'
-        mock_openAI.return_value = mock_response
+        mock_openAI.return_value = '"Updated CANMAT/ISBD Guidelines for Treating Mixed Features in Bipolar Disorder"'
 
         result = title.generate_title(doc)
 
@@ -89,10 +83,7 @@ class TestGenerateTitle(unittest.TestCase):
         doc.metadata = {"title": None}
         doc[0].get_text.return_value = []
 
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "A" * 300
-        mock_openAI.return_value = mock_response
+        mock_openAI.return_value = "A" * 300
 
         result = title.generate_title(doc)
 

--- a/server/api/views/uploadFile/title.py
+++ b/server/api/views/uploadFile/title.py
@@ -58,6 +58,6 @@ def summarize_pdf(pdf: fitz.Document) -> str:
     prompt = "Please provide a title for this document. The title should be less than 256 characters and will be displayed on a webpage."
     response = openAIServices.openAI(
         first_page_content, prompt, model='gpt-4o', temp=0.0)
-    title = response.choices[0].message.content.strip().strip('"').strip("'")
+    title = response.strip().strip('"').strip("'")
     # Truncate to fit UploadFile model's max_length=255 title field as a final safeguard
     return title[:255]


### PR DESCRIPTION
## Description
`summarize_pdf()` in `title.py` crashed with `AttributeError: 'str' object has no attribute 'choices'` when the OpenAI fallback was triggered during file upload.


## Changes
`title.py`: Updated `summarize_pdf()` to treat the return value of `openAIServices.openAI()` as a string, since it already extracts `message.content` internally


`test_title.py`: Updated mock return values from mock response objects with `.choices[0].message.content` to plain strings, matching the actual return type of `openAIServices.openAI()`


## Related Issue
Fixes #473 


## Manual Tests
Uploaded a PDF that uses the OpenAI fallback, confirmed that file was uploaded successfully, title was processed with no errors, and the generated title was correct.


## Automated Tests
Updated the unit tests related to OpenAI services in `test_title.py` to reflect the actual data types

## Reviewers
@sahilds1 
