### PR TITLE
refactor: file upload uses font size and more lenient regex to extract titles

### DIFF
--- a/server/api/views/uploadFile/test_title.py
+++ b/server/api/views/uploadFile/test_title.py
@@ -4,6 +4,39 @@ from unittest.mock import MagicMock, patch
 from . import title
 
 
+def make_page_dict(blocks):
+    """Helper to build a get_text("dict") return value from a simple list of blocks.
+    Each block is a list of (text, font_size) tuples representing spans.
+    """
+    dict_blocks = []
+    for spans in blocks:
+        dict_blocks.append({
+            "type": 0,
+            "lines": [{
+                "spans": [{"text": text, "size": size} for text, size in spans]
+            }]
+        })
+    return {"blocks": dict_blocks}
+
+
+def make_mock_doc(pages_data, metadata=None):
+    """Build a mock fitz.Document.
+    pages_data: list of block lists, one per page. Each block is a list of (text, size) tuples.
+    """
+    doc = MagicMock()
+    doc.metadata = metadata or {"title": None}
+    doc.__len__ = lambda self: len(pages_data)
+
+    mock_pages = []
+    for page_blocks in pages_data:
+        page = MagicMock()
+        page.get_text.return_value = make_page_dict(page_blocks)
+        mock_pages.append(page)
+
+    doc.__getitem__ = lambda self, idx: mock_pages[idx]
+    return doc
+
+
 class TestGenerateTitle(unittest.TestCase):
     def test_prefers_metadata_title_if_valid(self):
         doc = MagicMock()
@@ -11,53 +44,35 @@ class TestGenerateTitle(unittest.TestCase):
         self.assertEqual(
             "A Study Regarding The Efficacy of Drugs", title.generate_title(doc))
 
-    def test_falls_back_to_first_page_text_if_metadata_title_is_empty(self):
-        doc = MagicMock()
-        doc.metadata = {"title": ""}
-        doc[0].get_text = MagicMock()
-
-        foo_block = [None] * 7
-        foo_block[4] = "foo"
-        foo_block[6] = 0
-
-        title_block = [None] * 7
-        title_block[4] = "Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia"
-        title_block[6] = 0
-
-        bar_block = [None] * 7
-        bar_block[4] = "bar"
-        bar_block[6] = 0
-        doc[0].get_text.return_value = [foo_block, title_block, bar_block]
-
+    def test_falls_back_to_font_size_if_metadata_title_is_empty(self):
+        doc = make_mock_doc(
+            pages_data=[[
+                [("foo", 10.0)],
+                [("Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia", 18.0)],
+                [("bar", 10.0)],
+            ]],
+            metadata={"title": ""},
+        )
         expected_title = "Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia"
         self.assertEqual(expected_title, title.generate_title(doc))
 
-    def test_falls_back_to_first_page_text_if_metadata_title_does_not_match_regex(self):
-        doc = MagicMock()
-        doc.metadata = {"title": "abcd1234"}
-        doc[0].get_text = MagicMock()
-
-        foo_block = [None] * 7
-        foo_block[4] = "foo"
-        foo_block[6] = 0
-
-        title_block = [None] * 7
-        title_block[4] = "Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia"
-        title_block[6] = 0
-
-        bar_block = [None] * 7
-        bar_block[4] = "bar"
-        bar_block[6] = 0
-        doc[0].get_text.return_value = [foo_block, title_block, bar_block]
-
+    def test_falls_back_to_font_size_if_metadata_title_does_not_match_regex(self):
+        doc = make_mock_doc(
+            pages_data=[[
+                [("foo", 10.0)],
+                [("Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia", 18.0)],
+                [("bar", 10.0)],
+            ]],
+            metadata={"title": "abcd1234"},
+        )
         expected_title = "Advances in Mood Disorder Pharmacotherapy: Evaluating New Antipsychotics and Mood Stabilizers for Bipolar Disorder and Schizophrenia"
         self.assertEqual(expected_title, title.generate_title(doc))
 
     @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_falls_back_to_chatgpt_if_no_title_found(self, mock_openAI):
-        doc = MagicMock()
-        doc.metadata = {"title": None}
-        doc[0].get_text.return_value = []
+        doc = make_mock_doc(
+            pages_data=[[]]  # no blocks at all
+        )
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -70,9 +85,7 @@ class TestGenerateTitle(unittest.TestCase):
 
     @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_strips_quotes_from_openai_title(self, mock_openAI):
-        doc = MagicMock()
-        doc.metadata = {"title": None}
-        doc[0].get_text.return_value = []
+        doc = make_mock_doc(pages_data=[[]])
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -85,9 +98,7 @@ class TestGenerateTitle(unittest.TestCase):
 
     @patch("api.views.uploadFile.title.openAIServices.openAI")
     def test_truncates_long_openai_title(self, mock_openAI):
-        doc = MagicMock()
-        doc.metadata = {"title": None}
-        doc[0].get_text.return_value = []
+        doc = make_mock_doc(pages_data=[[]])
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -98,3 +109,55 @@ class TestGenerateTitle(unittest.TestCase):
 
         # Ensure the title is truncated to fit the UploadFile model's title field (max_length=255), since OpenAI responses may exceed this limit
         self.assertLessEqual(len(result), 255)
+
+    def test_font_size_joins_adjacent_spans_in_same_block(self):
+        """A title split across multiple spans in the same block should be joined."""
+        doc = make_mock_doc(
+            pages_data=[[
+                [("Author Name", 10.0)],
+                [("Advances in Mood Disorder", 18.0), ("Pharmacotherapy", 18.0)],
+                [("Some journal info", 10.0)],
+            ]],
+        )
+        result = title.extract_title_by_font_size(doc)
+        self.assertEqual(result, "Advances in Mood Disorder Pharmacotherapy")
+
+    def test_font_size_ignores_short_spans(self):
+        """Superscript markers and other tiny spans should be filtered out."""
+        doc = make_mock_doc(
+            pages_data=[[
+                [("Advances in Mood Disorder Pharmacotherapy", 18.0), ("*", 18.0)],
+                [("Author Name et al.", 10.0)],
+            ]],
+        )
+        # The "*" span is < 2 chars, so it should be ignored; title is just the real text
+        result = title.extract_title_by_font_size(doc)
+        self.assertEqual(result, "Advances in Mood Disorder Pharmacotherapy")
+
+    def test_font_size_returns_none_when_no_regex_match(self):
+        """If the largest-font text doesn't match the title regex, return None."""
+        doc = make_mock_doc(
+            pages_data=[[
+                # Only 2 words — regex requires at least 3
+                [("Psychiatry Research", 18.0)],
+                [("Author Name et al.", 10.0)],
+            ]],
+        )
+        result = title.extract_title_by_font_size(doc)
+        self.assertIsNone(result)
+
+    def test_font_size_finds_title_on_later_page(self):
+        """Title on page 2 should still be found if it has the largest font."""
+        doc = make_mock_doc(
+            pages_data=[
+                [  # page 1: cover page with smaller text
+                    [("Some preamble text here", 12.0)],
+                ],
+                [  # page 2: actual title in larger font
+                    [("Advances in Mood Disorder Pharmacotherapy", 18.0)],
+                    [("Author Name et al.", 10.0)],
+                ],
+            ],
+        )
+        result = title.extract_title_by_font_size(doc)
+        self.assertEqual(result, "Advances in Mood Disorder Pharmacotherapy")

--- a/server/api/views/uploadFile/title.py
+++ b/server/api/views/uploadFile/title.py
@@ -15,33 +15,78 @@ def generate_title(pdf: fitz.Document) -> str | None:
     document_metadata_title = pdf.metadata["title"]
     if document_metadata_title is not None and document_metadata_title != "":
         if title_regex.match(document_metadata_title):
-            print("suitable title was found in metadata")
             return document_metadata_title.strip()
-        else:
-            print("metadata title did not match regex")
 
-    print("Looking for title in first page text")
-    first_page = pdf[0]
-    first_page_blocks = first_page.get_text("blocks")
-    text_blocks = [
-        block[4].strip().replace("\n", " ")
-        for block in first_page_blocks
-        if block[6] == 0  # only include text blocks.
-    ]
+    font_title = extract_title_by_font_size(pdf)
+    if font_title:
+        return font_title
 
-    # For some reason, extracted PDF text has extra spaces. Collapse them here.
-    regex = r"\s{2,}"
-    text_blocks = [re.sub(regex, " ", text) for text in text_blocks]
-
-    if len(text_blocks) != 0:
-        for text in text_blocks:
-            if title_regex.match(text):
-                return text
-
-    print(
-        "no suitable title found in first page text. Using GPT-4 to summarize the PDF")
     gpt_title = summarize_pdf(pdf)
     return gpt_title or None
+
+
+def extract_title_by_font_size(pdf: fitz.Document, max_pages: int = 3) -> str | None:
+    """
+    Extract the title by finding the largest font size across the first few pages
+    and collecting contiguous runs of text at that size.
+    """
+    pages_to_scan = min(max_pages, len(pdf))
+
+    # First pass: collect all spans with their font size, and find the max font size.
+    all_spans = []
+    max_font_size = 0.0
+
+    for page_idx in range(pages_to_scan):
+        page_dict = pdf[page_idx].get_text("dict")
+        for block in page_dict["blocks"]:
+            if block.get("type") != 0:
+                continue
+            for line in block["lines"]:
+                for span in line["spans"]:
+                    text = span["text"].strip()
+                    size = span["size"]
+                    if len(text) < 2 or size < 6.0:
+                        continue
+                    all_spans.append({"text": text, "size": size})
+                    if size > max_font_size:
+                        max_font_size = size
+
+    if max_font_size == 0.0:
+        return None
+
+    # Second pass: gather contiguous runs of spans at the max font size.
+    # Runs continue across block boundaries so multi-block titles (e.g.,
+    # "BIPOLAR DISORDER IN PRIMARY CARE:" in one block and "DIAGNOSIS AND
+    # MANAGEMENT" in the next) are joined into a single candidate.
+    # A run only ends when a non-max-size span interrupts it.
+    candidates = []
+    current_run = []
+
+    for span in all_spans:
+        if span["size"] == max_font_size:
+            current_run.append(span["text"])
+        else:
+            if current_run:
+                candidates.append(" ".join(current_run))
+                current_run = []
+
+    if current_run:
+        candidates.append(" ".join(current_run))
+
+    # Collapse extra whitespace, validate against title regex, and pick the longest match.
+    # Longest wins because real titles are typically longer than section headers
+    # (e.g., "About the Author") that may share the same max font size.
+    best = None
+    for candidate in candidates:
+        cleaned = re.sub(r"\s{2,}", " ", candidate).strip()
+        if title_regex.match(cleaned):
+            if best is None or len(cleaned) > len(best):
+                best = cleaned
+
+    if best:
+        return best[:255]
+
+    return None
 
 
 def summarize_pdf(pdf: fitz.Document) -> str:

--- a/server/api/views/uploadFile/title.py
+++ b/server/api/views/uploadFile/title.py
@@ -6,9 +6,9 @@ from api.services.openai_services import openAIServices
 
 
 # regular expression to match common research white paper titles. Created by Chat-gpt
-# requires at least 3 words, no dates, no version numbers.
+# requires at least 3 words, no version numbers.
 title_regex = re.compile(
-    r'^(?=(?:\b\w+\b[\s:,\-\(\)]*){3,})(?!.*\b(?:19|20)\d{2}\b)(?!.*\bv\d+\b)[A-Za-z0-9][\w\s:,\-\(\)]*[A-Za-z\)]$', re.IGNORECASE)
+    r"^(?=(?:\b\w+\b[^A-Za-z0-9]*){3,})(?!.*\bv\d+\b)[A-Za-z0-9].+[A-Za-z\)?!]$", re.IGNORECASE)
 
 
 def generate_title(pdf: fitz.Document) -> str | None:


### PR DESCRIPTION
## Description
This PR replaces block-position title extraction with font-size-based approach. The old logic used `get_text("blocks")` and picked the first block matching a title regex, which frequently selected preambles, journal names, and article headers instead of the actual title. The new approach uses `get_text("dict")` to find the largest font size across the first few pages and collects contiguous runs of text at that size.

Also refactored the regex to be more lenient. With the new font-size-based approach, we can have more trust that the selected title is correct and just rely on the regex as a final rejecter.

Both of these refactors together make our uploadFile title extraction flow more accurate, resulting in less manual editing after the upload.

## Related Issue
Fixes #469 

### How it works
Title extraction follows a 3-tier fallback:
1. Metadata — use the PDF's embedded title if it passes the regex
2. **Font size (new)** — scan the first 3 pages, find the max font size, collect contiguous runs of text at that size, pick the longest regex-matching candidate
3. GPT-4 fallback — Ask OpenAI to find the title by giving it the first page

### Regex refactoring
Loosens the title validation regex to allow years, question marks, exclamation marks, apostrophes (like `'`), and unicode spaces (`\xa0`) in titles, all of which appeared in real PDF titles and were rejected when they shouldn't have been. The old regex was too restrictive. Just this fix resulted in a decrease in error rate from ~25% to 8%. 

For context, any title (regardless of how it's extracted) must match this regex. It has the final say when accepting or rejecting a title. We can treat this as a final sanity-check filter rather than the specific filter that was the old regex.  

Examples of actual titles the previous regex didn't accept but the new one does:
- `A systematic review and meta‐analysis of treatments for rapid cycling bipolar disorder` 
  - this was rejected because old regex used `[\w\s:,\-\(\)]*`, explicitly allowing only those specific characters. The uni-code hyphen (not in the allowlist--that was an ascii hyphen) was rejected.
- `Canadian Network for Mood and Anxiety Treatments (CANMAT) and International Society for Bipolar Disorders (ISBD) 2018 guidelines for the management of patients with bipolar disorder`
  - has a year in the title
- `Clinicians’ preferences and attitudes towards the use of lithium in the maintenance treatment of bipolar disorders around the world: a survey from the ISBD Lithium task force`
  - curly apostrophe `'`
 
The regex guards that remain are:
- must start with a letter or digit
- must end with a letter, ), ?, or !
- must have at least 3 words
- no version numbers (v1, v2, etc)  

### Font size title extraction
The old 2nd fallback approach used `get_text("blocks")`, which returns text blocks as flat strings with no formatting info. It just iterated through blocks on page 1 in order and picked the first one matching the title regex. So if a preamble, journal name, or article header appeared before the title, it would get selected instead.

The new approach uses `get_text("dict")`, which returns structured data including per-span font size. The key insight is that, in academic papers, the title is almost always rendered in the largest font on the page. It works like this:
1. Scans all text spans across the first 3 pages and records each span's text and font size
2. Finds the maximum font size across all spans
3. Groups consecutive spans at that max size into candidates (so a title split across multiple spans or blocks gets reassembled into one string--the old approach was missing this kind of logic as well)
4. Validates each candidate against the title regex and picks the longest match, since real titles tend to be longer than section headers that might share the same font size

Because this approach extracted the title more reliably (see manual tests), we can let the regex be more lenient. 

## Manual Tests
Before making these changes, [I tested 50 file uploads ](https://docs.google.com/spreadsheets/d/1RR5T0uAKBDMy5ZD4TMJJ774DTYbNCDGLs2aWefQ6CfA/edit?usp=sharing). 12 were incorrectly extracting titles, and all incorrect titles used the text blocks fallback.

I refactored the regex after looking into the files' metadata and then tested uploading all 50 files again. This time, 4/50 were incorrect. The regex loosening corrected most of the incorrect titles, but the problems with the text-block approach were still there.
After making changes and implementing the font-size approach as a replacement for the text blocks approach, I wrote/rewrote the unit tests and got them passing. I end-to-end manually tested the same set of files (with the exception of some of the files that were already passing with the metadata approach--my changes wouldn't have yielded a different outcome for these). In this round of testing, only 1 out of the 50 files had an incorrect title, and it was an article where the title was not the largest text. This is pretty rare and, even if we accept this limitation, the success rate is much better than the original implementation.

TLDR manual tests: OG implementation had 75% success rate, just regex refactoring had an 92% success rate, and regex + font size approach had a 98% success rate for the 50 test files.

## Automated Tests
it's a lot but writing it all here to document it

- Test helpers added (`make_page_dict`, `make_mock_doc`): 
  - The old tests built mock `fitz.Document` objects by hand using 7-element tuples to match the `get_text("blocks")` format. Since the new extraction uses `get_text("dict")`, these helpers build mocks with the structured dict format (blocks -> lines -> spans with text and size fields). They also support multi-page documents, which the old mocks didn't.
- Replaced existing tests for the original first-page-text-blocks approach with tests for the new font-size approach. Now, `test_falls_back_to_font_size_if_metadata_title_is_empty` and `test_falls_back_to_font_size_if_metadata_title_does_not_match_regex` use `make_mock_doc` with font-size-annotated spans so the font-size extractor can find a title.
-  Edited `test_falls_back_to_chatgpt_if_no_title_found`, `test_strips_quotes_from_openai_title`, and `test_truncates_long_openai_title` to use `make_mock_doc` for consistency, so that all tests build their mocks the same way.
- Added `test_font_size_returns_none_when_no_regex_match`-- verifies that largest-font text that doesn't match the title regex (e.g., "Psychiatry Research" with only 2 words) should cause the function to return None, falling through to the OpenAI fallback.
- Added `test_font_size_joins_adjacent_spans_in_same_block` -- verifies that a title split across multiple spans (ex:  "Advances in Mood Disorder" + "Pharmacotherapy") is joined into a single candidate.
- Added `test_font_size_finds_title_on_later_page`-- verifies that a title on page 2 is found when it has a larger font size than page 1 text.
- Added `test_font_size_ignores_short_spans`--Some files have spans that are superscript markets like `*`. Verifies that spans of less than 2 chars are filtered out, even if they share max font size. 

## Reviewers
@sahilds1 @taichan03 