### PR TITLE
Configure CORS Allowed Origins via ConfigMaps

### DIFF
--- a/deploy/manifests/balancer/base/deployment.yaml
+++ b/deploy/manifests/balancer/base/deployment.yaml
@@ -21,6 +21,8 @@ spec:
           envFrom:
             - secretRef:
                 name: balancer-config
+            - configMapRef:
+                name: balancer-config
           ports:
             - containerPort: 8000
           readinessProbe:

--- a/deploy/manifests/balancer/base/kustomization.yaml
+++ b/deploy/manifests/balancer/base/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 
 configMapGenerator:
   - name: balancer-config
+    envs:
+      - balancer.env

--- a/deploy/manifests/balancer/base/kustomization.yaml
+++ b/deploy/manifests/balancer/base/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+
+configMapGenerator:
+  - name: balancer-config

--- a/deploy/manifests/balancer/overlays/production/balancer.env
+++ b/deploy/manifests/balancer/overlays/production/balancer.env
@@ -1,0 +1,1 @@
+CORS_ALLOWED_ORIGINS=https://balancerproject.org

--- a/deploy/manifests/balancer/overlays/production/configmap.yaml
+++ b/deploy/manifests/balancer/overlays/production/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: balancer-config
+data:
+  CORS_ALLOWED_ORIGINS: "https://balancerproject.org"

--- a/deploy/manifests/balancer/overlays/production/configmap.yaml
+++ b/deploy/manifests/balancer/overlays/production/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: balancer-config
-data:
-  CORS_ALLOWED_ORIGINS: "https://balancerproject.org"

--- a/deploy/manifests/balancer/overlays/production/kustomization.yaml
+++ b/deploy/manifests/balancer/overlays/production/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: configmap.yaml

--- a/deploy/manifests/balancer/overlays/production/kustomization.yaml
+++ b/deploy/manifests/balancer/overlays/production/kustomization.yaml
@@ -4,5 +4,8 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  - path: configmap.yaml
+configMapGenerator:
+  - name: balancer-config
+    behavior: merge
+    envs:
+      - balancer.env

--- a/deploy/manifests/balancer/overlays/sandbox/balancer.env
+++ b/deploy/manifests/balancer/overlays/sandbox/balancer.env
@@ -1,0 +1,1 @@
+CORS_ALLOWED_ORIGINS=https://sandbox.balancerproject.org

--- a/deploy/manifests/balancer/overlays/sandbox/configmap.yaml
+++ b/deploy/manifests/balancer/overlays/sandbox/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: balancer-config
-data:
-  CORS_ALLOWED_ORIGINS: "https://sandbox.balancerproject.org"

--- a/deploy/manifests/balancer/overlays/sandbox/configmap.yaml
+++ b/deploy/manifests/balancer/overlays/sandbox/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: balancer-config
+data:
+  CORS_ALLOWED_ORIGINS: "https://sandbox.balancertestsite.com"

--- a/deploy/manifests/balancer/overlays/sandbox/configmap.yaml
+++ b/deploy/manifests/balancer/overlays/sandbox/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: balancer-config
 data:
-  CORS_ALLOWED_ORIGINS: "https://sandbox.balancertestsite.com"
+  CORS_ALLOWED_ORIGINS: "https://sandbox.balancerproject.org"

--- a/deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
+++ b/deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: configmap.yaml

--- a/deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
+++ b/deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
@@ -4,5 +4,8 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  - path: configmap.yaml
+configMapGenerator:
+  - name: balancer-config
+    behavior: merge
+    envs:
+      - balancer.env

--- a/server/balancer_backend/settings.py
+++ b/server/balancer_backend/settings.py
@@ -67,7 +67,10 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "balancer_backend.urls"
 
-CORS_ALLOW_ALL_ORIGINS = True
+# CORS configuration
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+# Ensure no empty strings if input was empty or trailing comma
+CORS_ALLOWED_ORIGINS = [origin.strip() for origin in CORS_ALLOWED_ORIGINS if origin.strip()]
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Addresses https://github.com/CodeForPhilly/balancer-main/issues/497

This PR makes CORS allowed origins configurable via environment variables and Kubernetes ConfigMaps.

Changes:
- Modified `server/balancer_backend/settings.py` to read `CORS_ALLOWED_ORIGINS` from environment, defaulting to `localhost:3000`.
- Updated base deployment manifest to include `envFrom` from a ConfigMap named `balancer-config`.
- Added an empty `configMapGenerator` to the base `kustomization.yaml`.
- Created `sandbox` and `production` overlays with their respective `CORS_ALLOWED_ORIGINS` configured in a `configmap.yaml` patch.

Deployment note: Ensure that the `balancer-config` ConfigMap is created or generated in the target namespace.