### PR TITLE
Rename 'Click To Enter New Patient' button to 'Enter New Patient'

### DIFF
--- a/frontend/src/pages/PatientManager/NewPatientForm.tsx
+++ b/frontend/src/pages/PatientManager/NewPatientForm.tsx
@@ -310,7 +310,7 @@ const NewPatientForm = ({
           >
             <div className="flex items-center justify-between">
               <h2 className="text-xl font-bold text-gray-600 cursor-pointer header_logo font-satoshi hover:text-blue-600 ">
-                Click To Enter New Patient
+                Enter New Patient
               </h2>
 
               <div


### PR DESCRIPTION
Closes #509.

Drops the leading 'Click To' on the patient-summary button for accessibility (not every user is on a click-capable device) and to match the standard concise button labeling convention.