### PR TITLE
Fix mobile nav 'Medication Suggester' link target and label

### DIFF
--- a/frontend/src/components/Header/MdNavBar.tsx
+++ b/frontend/src/components/Header/MdNavBar.tsx
@@ -89,10 +89,10 @@ const MdNavBar = (props: LoginFormProps) => {
                     </li>
                     <li className="border-b border-gray-300 p-4">
                         <Link
-                            to="/login"
+                            to="/"
                             className="mr-9 text-black hover:border-b-2 hover:border-blue-600 hover:text-black hover:no-underline"
                         >
-                            Medical Suggester
+                            Medication Suggester
                         </Link>
                     </li>
                     <li className="border-b border-gray-300 p-4">


### PR DESCRIPTION
Closes #494.

The mobile nav had two issues with the suggester link:

1. **Wrong target.** The link pointed at `/login`, which sent already-logged-in users back to the login page instead of the suggester. Point at `/` to match the desktop header at [Header.tsx:124](https://github.com/CodeForPhilly/balancer-main/blob/develop/frontend/src/components/Header/Header.tsx#L124).
2. **Wrong label.** Said 'Medical Suggester'; everywhere else in the app says 'Medication Suggester'. Renamed for consistency.