### PR TITLE
feat: update DB config defaults from RDS to CloudNativePG

### DIFF
--- a/config/env/dev.env.example
+++ b/config/env/dev.env.example
@@ -10,13 +10,14 @@ SQL_PASSWORD=balancer
 
 # Connection Type Examples:
 # 
-# CloudNativePG (Kubernetes service within cluster):
-#   SQL_HOST=balancer-postgres-rw
-#   SQL_HOST=balancer-postgres-rw.balancer.svc.cluster.local
+# CloudNativePG (primary — Philthy Civic Cloud shared cluster):
+#   SQL_HOST=shared-cluster-rw.cloudnative-pg.svc.cluster.local
+#   SQL_DATABASE=balancer
 #   (SSL typically not required within cluster)
 #
-# AWS RDS (External database):
+# AWS RDS (legacy — for migration contexts):
 #   SQL_HOST=balancer-db.xxxxx.us-east-1.rds.amazonaws.com
+#   SQL_DATABASE=balancer_dev
 #   (SSL typically required - set SQL_SSL_MODE if needed)
 #
 # Local development:

--- a/deploy/manifests/balancer/base/secret.template.yaml
+++ b/deploy/manifests/balancer/base/secret.template.yaml
@@ -6,6 +6,9 @@
 # repository. Secrets should be created in each target cluster using cluster-specific
 # tools (e.g., SealedSecrets in the cfp-sandbox-cluster).
 #
+# CloudNativePG is the primary database target (Philthy Civic Cloud shared cluster).
+# AWS RDS was used previously and may still be referenced for migration contexts.
+#
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,8 +23,10 @@ stringData:
   REACT_APP_API_BASE_URL: https://balancer.sandbox.k8s.phl.io/
   SECRET_KEY: randomly_generated_key_ere
   SQL_ENGINE: django.db.backends.postgresql
-  SQL_HOST: sql_host_here
+  # CloudNativePG (primary): shared-cluster-rw.cloudnative-pg.svc.cluster.local
+  # AWS RDS (legacy):        balancer-db.xxxxx.us-east-1.rds.amazonaws.com
+  SQL_HOST: shared-cluster-rw.cloudnative-pg.svc.cluster.local
   SQL_PORT: '5432'
-  SQL_DATABASE: balancer_dev
+  SQL_DATABASE: balancer
   SQL_USER: balancer
   SQL_PASSWORD: sql_password_here

--- a/server/api/views/assistant/eval_assistant.py
+++ b/server/api/views/assistant/eval_assistant.py
@@ -33,11 +33,9 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "balancer_backend.settings")
 import django
 django.setup()
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model  # noqa: E402
 
-from api.views.assistant.assistant_services import run_assistant
-# TODO: remove unused import or use INSTRUCTIONS to record an instructions_hash column
-from api.views.assistant.assistant_prompts import INSTRUCTIONS
+from api.views.assistant.assistant_services import run_assistant  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/server/balancer_backend/urls.py
+++ b/server/balancer_backend/urls.py
@@ -6,6 +6,9 @@ from django.urls import path, include, re_path
 # Import TemplateView for rendering templates
 from django.views.generic import TemplateView
 import importlib  # Import the importlib module for dynamic module importing
+import os
+from django.conf import settings
+from django.http import HttpResponseNotFound
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 
@@ -57,10 +60,6 @@ urlpatterns += [
     path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
 ]
-
-import os
-from django.conf import settings
-from django.http import HttpResponseNotFound
 
 
 def spa_fallback(request):


### PR DESCRIPTION
## Description

Updates the deployment manifests and environment docs to reflect that CloudNativePG on the Philly Civic Cloud shared cluster is now the primary database target, replacing the legacy AWS RDS instance.

### Changes

- **`deploy/manifests/balancer/base/secret.template.yaml`** — Updated `SQL_HOST` to `shared-cluster-rw.cloudnative-pg.svc.cluster.local`, `SQL_DATABASE` to `balancer`, and added inline docs for both CNPG (primary) and RDS (legacy) host patterns
- **`config/env/dev.env.example`** — Updated connection type examples to document CNPG as primary, RDS as legacy/migration

### Related

- Closes #464
- Related: CodeForPhilly/cfp-sandbox-cluster#162 (cluster-side DB cutover)