### PR TITLE
docs: add local frontend and API notes (localhost:3000/8000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Tools used for development:
 
 Start the Postgres, Django REST, and React services by starting Docker Desktop and running `docker compose up --build` 
 
+Local development servers:
+
+- **Frontend (React dev server):** http://localhost:3000 — when developing locally, open the React app at this address. 
+- **Backend / API (Django):** http://localhost:8000
+  - *Note:* if you open http://localhost:8000 in a browser you will see  a minimal single-page fallback for the frontend, which is non-functional for development. To view the working frontend during development, use http://localhost:3000.
+
 #### Postgres
 
 The application supports connecting to PostgreSQL databases via:


### PR DESCRIPTION
## Description
This PR adds notes about opening the application on local development servers. This will direct new developers to the correct localhost port.


## Related Issue
This issue was uncovered by accidentally trying to run the application from localhost:8000 and finding that although a React application appears, it does not work and acts as a fallback page.


## Manual Tests
N/A


## Automated Tests
N/A


## Documentation
N/A


## Reviewers
@sahilds1 


## Notes
<!-- Any additional context, concerns, or discussion points for reviewers -->