### PR TITLE
fix: add HTTP redirect route to ListenerSet for apex domain

### DIFF
--- a/deploy/manifests/balancer/base/gateway-listeners.yaml
+++ b/deploy/manifests/balancer/base/gateway-listeners.yaml
@@ -3,7 +3,7 @@ kind: ListenerSet
 metadata:
   name: balancer-listeners
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod-gateway
     hostname: HOSTNAME_PLACEHOLDER
 spec:
   parentRef:

--- a/deploy/manifests/balancer/base/httproute.yaml
+++ b/deploy/manifests/balancer/base/httproute.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -21,3 +20,24 @@ spec:
       backendRefs:
         - name: balancer
           port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: balancer-http-redirect
+  annotations:
+    hostname: HOSTNAME_PLACEHOLDER
+spec:
+  parentRefs:
+    - name: balancer-listeners
+      kind: ListenerSet
+      group: gateway.networking.k8s.io
+      sectionName: http
+  hostnames:
+    - HOSTNAME_PLACEHOLDER
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/deploy/manifests/balancer/base/kustomization.yaml
+++ b/deploy/manifests/balancer/base/kustomization.yaml
@@ -22,3 +22,6 @@ configMapGenerator:
   - name: balancer-config
     envs:
       - balancer.env
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/manifests/balancer/overlays/production/kustomization.yaml
+++ b/deploy/manifests/balancer/overlays/production/kustomization.yaml
@@ -42,3 +42,10 @@ patches:
       - op: replace
         path: /spec/hostnames/0
         value: balancerproject.org
+  - target:
+      kind: HTTPRoute
+      name: balancer-http-redirect
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: balancerproject.org

--- a/deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
+++ b/deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
@@ -44,6 +44,13 @@ patches:
         path: /spec/hostnames/0
         value: sandbox.balancerproject.org
   - target:
+      kind: HTTPRoute
+      name: balancer-http-redirect
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: sandbox.balancerproject.org
+  - target:
       kind: Deployment
       name: balancer
     patch: |


### PR DESCRIPTION
## Description

Fixes the HTTP 404 issue for `balancerproject.org` apex when DNS points at the Envoy LB. The per-app ListenerSet claimed the apex hostname for HTTPS only, which prevented the shared `main-gateway`'s HTTP→HTTPS redirect from applying.

### Changes

- **`base/httproute.yaml`** — Added `balancer-http-redirect` HTTPRoute attached to the `sectionName: http` listener, returning 301→HTTPS
- **`base/gateway-listeners.yaml`** — Updated ClusterIssuer annotation to `letsencrypt-prod-gateway` (matches the cluster's Gateway-specific issuer)
- **`base/kustomization.yaml`** — Added `generatorOptions.disableNameSuffixHash: true` to prevent ConfigMap hash suffix causing ArgoCD drift
- **`overlays/production/kustomization.yaml`** — Added patch for new `balancer-http-redirect` hostname
- **`overlays/sandbox/kustomization.yaml`** — Added patch for new `balancer-http-redirect` hostname

### Related

- Refs CodeForPhilly/cfp-live-cluster#160

### Verification

```
kustomize build deploy/manifests/balancer/overlays/production/  # PASS
kustomize build deploy/manifests/balancer/overlays/sandbox/    # PASS
```

Both builds include the redirect HTTPRoute with correct hostname.